### PR TITLE
Add quiz ID tracking and improve accuracy endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,6 +55,11 @@ def create_app(config_class: type = Config) -> Flask:
             db.session.execute(text("ALTER TABLE score_log ADD COLUMN time_taken INTEGER"))
             db.session.commit()
 
+        cols = [c["name"] for c in insp.get_columns("guess_log")]
+        if "quiz_id" not in cols:
+            db.session.execute(text("ALTER TABLE guess_log ADD COLUMN quiz_id VARCHAR(120)"))
+            db.session.commit()
+
     @login.user_loader
     def load_user(user_id: str):
         """Return user object from session-stored user_id."""

--- a/app/models.py
+++ b/app/models.py
@@ -30,6 +30,7 @@ class GuessLog(db.Model):
     is_correct  = db.Column(db.Boolean, default=False)
     used_hint   = db.Column(db.Boolean, default=False)
     timestamp   = db.Column(db.DateTime, default=datetime.utcnow)
+    quiz_id     = db.Column(db.String(120), index=True)
 
     user = db.relationship("User", backref="guesses")
 

--- a/app/static/results.js
+++ b/app/static/results.js
@@ -2,7 +2,7 @@ $(function () {
     $("[data-player-name]").each(function () {
       const el = $(this);
       const playerName = el.data("player-name");
-      fetch(`/player_accuracy/${encodeURIComponent(playerName)}`)
+      fetch('/player_accuracy/' + encodeURIComponent(playerName) + '?quiz_id=' + encodeURIComponent(quizId))
         .then((res) => res.json())
         .then((data) => {
           const percent = data.accuracy || 0;

--- a/app/templates/quiz.html
+++ b/app/templates/quiz.html
@@ -649,7 +649,7 @@
     const el = $(this);
     const playerName = el.data("player-name");
 
-    fetch(`/player_accuracy/${encodeURIComponent(playerName)}`)
+    fetch('/player_accuracy/' + encodeURIComponent(playerName) + '?quiz_id=' + encodeURIComponent(quizId))
       .then((res) => res.json())
       .then((data) => {
         const percent = data.accuracy || 0;

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -182,6 +182,7 @@
     const shareMessage = {{ share_message|tojson }};
     const isAuthenticated = {{ 'true' if current_user.is_authenticated else 'false' }};
     const loginUrl = "{{ url_for('auth.login') }}";
+    const quizId = {{ quiz_id|tojson }};
   </script>
   <script src="{{ url_for('static', filename='results.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- track the quiz ID on guess logs
- migrate existing databases to include the new column
- store quiz ID whenever guesses are logged
- simplify leaderboard queries
- support quiz filtering in the `player_accuracy` endpoint
- pass quiz ID from frontend to accuracy API

## Testing
- `python -m py_compile app/__init__.py app/main/routes.py app/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874168b3c14832194186f07079eb164