### PR TITLE
Remove extraneous text from past quiz modal

### DIFF
--- a/app/templates/_archive_modal.html
+++ b/app/templates/_archive_modal.html
@@ -1,5 +1,3 @@
 <div id="archive-modal" class="archive-modal">
-  <h3>Past Quizzes</h3>
   <ul id="archive-list"></ul>
-  <a href="#" id="close-archive" class="leaderboard-link">Close</a>
 </div>

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -158,7 +158,7 @@
       {% if show_leaderboard %}
       <a href="#" id="view-leaderboard" class="leaderboard-link">view leaderboard</a>
       {% endif %}
-      <p class="past-quiz-line">Want to play past quizzes? <a href="#" id="view-past-quizzes" class="leaderboard-link">View Past Quizzes</a></p>
+      <p class="past-quiz-line"><a href="#" id="view-past-quizzes" class="leaderboard-link">View Past Quizzes</a></p>
       {% include '_archive_modal.html' %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- simplify archive modal template
- show only the "View Past Quizzes" link

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874400ecfa4832180cd8f918f8eb08d