### PR TITLE
Enhance quiz utilities and modal

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -181,6 +181,7 @@ def get_leaderboard(quiz_id):
         )
         .outerjoin(User, User.id == ScoreLog.user_id)
         .filter(ScoreLog.quiz_id == quiz_id)
+        .filter(ScoreLog.user_id.isnot(None))
         .order_by(ScoreLog.score.desc(), ScoreLog.time_taken.asc())
         .all()
     )

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -724,6 +724,16 @@ body {
   margin-bottom: 0.5rem;
 }
 
+.close-btn {
+  display: block;
+  margin-bottom: 0.75rem;
+  background: none;
+  border: 1px solid var(--gold);
+  color: var(--gold);
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
 .past-quiz-line {
   margin-top: 0.5rem;
   font-size: 0.6rem;

--- a/app/templates/_archive_modal.html
+++ b/app/templates/_archive_modal.html
@@ -1,3 +1,4 @@
 <div id="archive-modal" class="archive-modal">
+  <button id="close-archive" class="close-btn">Close</button>
   <ul id="archive-list"></ul>
 </div>

--- a/generate_quiz.py
+++ b/generate_quiz.py
@@ -3,6 +3,8 @@ import random
 import time
 import re
 from pathlib import Path
+from datetime import datetime
+from zoneinfo import ZoneInfo
 import pandas as pd
 from nba_api.stats.static import players
 from nba_api.stats.endpoints import (
@@ -17,6 +19,16 @@ DATA_PATH = Path(__file__).resolve().parent / "app" / "static" / "json" / "cbb25
 
 df_d1 = pd.read_csv(DATA_PATH)
 df_d1 = df_d1.rename(columns={"School": "Official", "Common name": "Common", "Primary": "Conference"})
+
+
+def today_filename(prefix=""):
+    """Return today's date string in America/New_York as ``YYYY-MM-DD.json``."""
+    tz = ZoneInfo("America/New_York")
+    today = datetime.now(tz).date()
+    name = today.strftime("%Y-%m-%d") + ".json"
+    if prefix:
+        return f"{prefix}{name}"
+    return name
 
 def clean_name(name):
     if not isinstance(name, str):
@@ -234,7 +246,7 @@ def generate_quiz_from_season(season, save_dir, manual_avatars=False, avatar_map
 
             if team_lineups:
                 selected = random.choice(team_lineups)
-                out_path = Path(save_dir) / f"{selected['season']}_{selected['game_id']}_{selected['team_abbr']}.json"
+                out_path = Path(save_dir) / today_filename()
                 with out_path.open("w", encoding="utf-8") as f:
                     json.dump(selected, f, indent=2, ensure_ascii=False)
                 print(f"Saved: {out_path}")

--- a/update_quiz.py
+++ b/update_quiz.py
@@ -10,14 +10,14 @@ PROJECT_ROOT   = os.path.abspath(os.path.dirname(__file__))  # /home/devgreeny/s
 PRELOADED_DIR  = os.path.join(PROJECT_ROOT, "app", "static", "preloaded_quizzes")
 CURRENT_DIR    = os.path.join(PROJECT_ROOT, "app", "static", "current_quiz")
 ARCHIVE_DIR    = os.path.join(PROJECT_ROOT, "app", "static", "archive_quizzes")
+BONUS_DIR      = os.path.join(PROJECT_ROOT, "app", "static", "bonus_quiz")
 # ────────────────────────────────────────────────────────────────────────────────
 
-def main():
-    # 1) Ensure necessary folders exist
+def archive_yesterdays_quiz():
+    """Move any JSON in ``CURRENT_DIR`` to ``ARCHIVE_DIR``."""
     os.makedirs(CURRENT_DIR, exist_ok=True)
     os.makedirs(ARCHIVE_DIR, exist_ok=True)
 
-    # 2) Move any existing quiz in CURRENT_DIR to ARCHIVE_DIR
     existing = [f for f in os.listdir(CURRENT_DIR) if f.lower().endswith(".json")]
     for old_file in existing:
         old_path = os.path.join(CURRENT_DIR, old_file)
@@ -28,24 +28,58 @@ def main():
         except Exception as e:
             print(f"⚠️ Could not archive '{old_file}': {e}", file=sys.stderr)
 
-    # 3) List all remaining quizzes in PRELOADED_DIR
+
+def update_current_quiz():
+    """Select a random quiz from ``PRELOADED_DIR`` and move it into ``CURRENT_DIR``."""
+    os.makedirs(CURRENT_DIR, exist_ok=True)
+    os.makedirs(PRELOADED_DIR, exist_ok=True)
+
     all_quizzes = [f for f in os.listdir(PRELOADED_DIR) if f.lower().endswith(".json")]
     if not all_quizzes:
         print("❌ No quizzes found in preloaded_quizzes. Nothing to do.", file=sys.stderr)
         sys.exit(1)
 
-    # 4) Pick one at random
     chosen = random.choice(all_quizzes)
     src_path = os.path.join(PRELOADED_DIR, chosen)
     dest_path = os.path.join(CURRENT_DIR, chosen)
 
-    # 5) Move it (cut & paste)
     try:
         shutil.move(src_path, dest_path)
         print(f"✅ Moved '{chosen}' → current_quiz")
+        return chosen
     except Exception as e:
         print(f"❌ Failed to move '{chosen}': {e}", file=sys.stderr)
         sys.exit(1)
+
+
+def prepare_bonus_quiz(exclude=None):
+    """Ensure ``BONUS_DIR`` contains at least one quiz."""
+    os.makedirs(BONUS_DIR, exist_ok=True)
+    existing = [f for f in os.listdir(BONUS_DIR) if f.lower().endswith(".json")]
+    if existing:
+        return
+
+    pool = [f for f in os.listdir(PRELOADED_DIR) if f.lower().endswith(".json")]
+    if exclude and exclude in pool:
+        pool.remove(exclude)
+    if not pool:
+        print("⚠️ No quizzes available for bonus quiz.", file=sys.stderr)
+        return
+
+    chosen = random.choice(pool)
+    src = os.path.join(PRELOADED_DIR, chosen)
+    dst = os.path.join(BONUS_DIR, chosen)
+    try:
+        shutil.copy(src, dst)
+        print(f"✅ Prepared bonus quiz: {chosen}")
+    except Exception as e:
+        print(f"⚠️ Failed to prepare bonus quiz '{chosen}': {e}", file=sys.stderr)
+
+
+def main():
+    archive_yesterdays_quiz()
+    chosen = update_current_quiz()
+    prepare_bonus_quiz(exclude=chosen)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- only show registered users on the leaderboard
- generate today's quiz filename in Eastern time
- archive previous quiz, move new quiz and prep bonus quiz
- add modal close button styling
- ensure past quizzes modal can be opened/closed

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687442e80ad88321879647a1a5d76f26